### PR TITLE
feat: inject DNS client into query via ECS 

### DIFF
--- a/examples/nginx-doh-and-dot-to-dns-inject.conf
+++ b/examples/nginx-doh-and-dot-to-dns-inject.conf
@@ -1,0 +1,131 @@
+# inject CSUBNET into dns queries (useful to pass client identification i.e. while DoT reverse-proxying pihole)
+
+user www-data;
+worker_processes  1;
+#worker_processes  auto;
+
+pid /run/nginx.pid;
+error_log  /var/log/nginx/dns-error.log notice;
+
+include /etc/nginx/modules-enabled/*.conf;
+
+
+events {
+    worker_connections  1024;
+}
+
+stream {
+
+  # DNS logging
+  log_format  dns   '$remote_addr [$time_local] $protocol $status $bytes_sent $bytes_received "$dns_qname" "$dns_client"';
+
+  access_log /var/log/nginx/dns-access.log dns;
+
+  # Import the NJS module
+  js_import /etc/nginx/njs.d/dns/dns.js;
+
+  # The $dns_qname variable can be populated by preread calls, and can be used for DNS routing
+  js_set $dns_qname dns.get_qname;
+
+  # The $dns_client variable can be populated by preread calls, and can be used for DNS routing
+  js_set $dns_client dns.get_client;
+
+
+### DNS over TLS reverse proxy ###
+
+  # DoT endpoint
+  server {
+    # listen to DNS over TLS
+    listen 853 ssl;
+
+    # SSL keys
+    ssl_certificate /etc/letsencrypt/live/pihole/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/pihole/privkey.pem; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+    # SSL settings 
+    #ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
+    ssl_protocols TLSv1.3;
+    ssl_prefer_server_ciphers on;
+
+    # listen to DNS over TCP
+    #listen 53;
+    # listen to DNS over UDP
+    #listen 53 udp;
+    # treat single udp packets (enable for UDP)
+    #proxy_responses 1;
+
+    # handle DoT request
+    js_preread dns.preread_dns_request;
+
+    # Upstream can be either DNS(TCP) or DoT.
+    proxy_pass 127.0.0.1:53;
+    # If upstream is DNS, proxy_ssl should be off.
+    #proxy_ssl on;
+  }
+
+
+### DNS over HTTPS reverse proxy ###
+
+  server {
+    # dohloop
+    listen unix:/tmp/dohloop.socket;
+    #listen 127.0.0.1:44353;
+    # handle DoH request
+    js_filter dns.filter_doh_request;
+
+    # Upstream can be either DNS(TCP) or DoT.
+    proxy_pass 127.0.0.1:53;
+    # If upstream is DNS, proxy_ssl should be off.
+    #proxy_ssl on;
+  }
+
+}
+
+http {
+  # DoH endpoint
+  server {
+    # listen to DNS over HTTPS
+    listen 443 ssl http2;
+    # listen to DNS over plain HTTP
+    #listen 80 http2;
+    # DoH requires HTTP/2
+    #http2 on;  # nginx>1.25
+
+    # SSL keys
+    ssl_certificate /etc/letsencrypt/live/pihole/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/pihole/privkey.pem; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+    
+    # SSL settings 
+    #ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
+    ssl_protocols TLSv1.3;
+    ssl_prefer_server_ciphers on;
+
+    # Return 404 to all responses, except for those using our published DoH URI
+    location / {
+      return 404 "404 Not Found\n";
+    }
+
+    location /dns-query {
+      # log settings off in favor of stream access log on stream
+      access_log off;
+
+      # Proxy HTTP/1.1
+      proxy_http_version 1.1;
+      # clear the connection header to enable Keep-Alive
+      proxy_set_header Connection "";
+      # pass client address
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      # proxy to dohloop
+      proxy_pass http://unix:/tmp/dohloop.socket;
+      #proxy_pass http://127.0.0.1:44353;
+    }
+
+    location /version {
+      js_import /etc/nginx/njs.d/utils.js;
+      js_content utils.version;
+    }
+  }
+}
+

--- a/njs.d/dns/dns.js
+++ b/njs.d/dns/dns.js
@@ -54,15 +54,12 @@ function process_doh_request(s, decode, scrub) {
     if ( data.length == 0 ) {
       return;
     }
-    var dataString = data.toString('utf8');
-    const lines = dataString.split("\r\n");
     var bytes;
     var packet;
-    if(lines[0].startsWith("GET")) {
-      var line = lines[0];
-      var path = line.split(" ")[1]
-      var params = path.split("?")[1]
-      var qs = params.split("&");
+    if(data.toString('utf8', 0, 3) == "GET") {
+      const path = data.toString('utf8', 4, data.indexOf(' ', 4));
+      const params = path.split("?")[1]
+      const qs = params.split("&");
       qs.some( param => {
         if (param.startsWith("dns=") ) {
           bytes = Buffer.from(param.slice(4), "base64url");
@@ -72,15 +69,8 @@ function process_doh_request(s, decode, scrub) {
       });
     }
 
-    if(lines[0].startsWith("POST")) {
-      const index = lines.findIndex(line=>{
-        if(line.length == 0) {
-          return true;
-        }
-      })
-      if(index>0 && lines.length >= index + 1){
-        bytes = Buffer.from(lines[index + 1]);
-      }
+    if(data.toString('utf8', 0, 4) == "POST") {
+      bytes = data.slice(data.indexOf('\r\n\r\n') + 4);
     }
 
     if (bytes) {

--- a/njs.d/dns/libdns.js
+++ b/njs.d/dns/libdns.js
@@ -533,7 +533,6 @@ function encode_srv_record( srv ) {
   rdata.writeInt16BE( srv.weight, 2 );
   rdata.writeInt16BE( srv.port, 4 );
   rdata = Buffer.concat( [ rdata, encode_label( srv.target ) ]);
-  ngx.log( ngx.WARN, rdata.toString('hex'));
   return rdata;
 }
 


### PR DESCRIPTION
Add client ip as ECS param in EDNS(0).
This provides useful in combination with Pi-hole (R) detecting clients by ECS.

see also https://github.com/pi-hole/FTL/pull/851 and Pi-hole setting `EDNS0_ECS=true` (default)

based on RFC7871
